### PR TITLE
feat: UDP punchthrough client (direct p2p)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Point to an `asset` directory. Assets aren't yet checked in, but SoOn !!
   - `game` - ECS goo, game object and scene management, etc.
   - `input` - device discovery, input mappings and such
   - `math` - vectors and matrices of various types, useful constants, helper functions
+  - `net` - p2p network communication
   - `memory` - custom allocators
   - `physics` - fixed-timestep simulation using fixed-point math
   - `core` - commonly-used classes and functionality across sputter

--- a/README.md
+++ b/README.md
@@ -62,3 +62,9 @@ Point to an `asset` directory. Assets aren't yet checked in, but SoOn !!
   - `ui` - a very rudimentary ui
 - src/exe/...
   -  where the games and experiments live
+## Style
+
+- Member variables use `m_` prefix.
+- Default values for classes go in the header.
+- Logging should be done through `glog` (include `#include <sputter/system/system.h` and look for `LOG` for examples)
+- Invalid input should be checked with `RELEASE_CHECK(bool, error message)`

--- a/src/exe/CMakeLists.txt
+++ b/src/exe/CMakeLists.txt
@@ -1,3 +1,4 @@
 cmake_minimum_required (VERSION 3.8 FATAL_ERROR)
 
 add_subdirectory(paddlearena)
+add_subdirectory(udp_client_test)

--- a/src/exe/udp_client_test/CMakeLists.txt
+++ b/src/exe/udp_client_test/CMakeLists.txt
@@ -1,0 +1,9 @@
+# TODO Find out why this isn't building the target
+cmake_minimum_required (VERSION 3.8 FATAL_ERROR)
+
+set(TARGETNAME udp_client_test)
+
+file(GLOB SOURCES *.cpp)
+add_executable(${TARGETNAME} ${SOURCES})
+
+include(${PROJECT_SOURCE_DIR}/cmake/SputterInc.cmake)

--- a/src/exe/udp_client_test/main.cpp
+++ b/src/exe/udp_client_test/main.cpp
@@ -91,29 +91,3 @@ int main(int argc, char* argv[]) {
   return 0;
 }
 
-// Server code
-// int main() {
-//   UDPPort server;
-// 
-//   // Open the server port for receiving data
-//   if (!server.open(8080)) {
-//     std::cerr << "Error: Failed to open server port\n";
-//     return 1;
-//   }
-// 
-//   // Receive data from the client
-//   char buffer[256];
-//   std::string address;
-//   uint16_t port;
-//   int received = server.receive(buffer, sizeof(buffer), address, port);
-//   if (received < 0) {
-//     std::cerr << "Error: Failed to receive data\n";
-//     return 1;
-//   }
-// 
-//   // Output the received message
-//   std::cout << "Received message from " << address << ":" << port << ": " << buffer << std::endl;
-// 
-//   return 0;
-// }
-// 

--- a/src/exe/udp_client_test/main.cpp
+++ b/src/exe/udp_client_test/main.cpp
@@ -5,6 +5,7 @@
 using namespace sputter::net;
 
 // Constants for RX port number, TX port number
+// TODO Have me automatically find a free port
 const int RX_PORT = 50000;
 const int TX_PORT = 50001;
 

--- a/src/exe/udp_client_test/main.cpp
+++ b/src/exe/udp_client_test/main.cpp
@@ -1,0 +1,57 @@
+#include <sputter/net/port.h>
+#include <iostream>
+#include <cstring>
+
+using namespace sputter::net;
+
+// Client code
+int main() {
+  sputter::net::UDPPort client;
+
+  // Open the client port for transmitting data
+  if (!client.open(50000)) {
+    std::cerr << "Error: Failed to open client port\n";
+    return 1;
+  }
+
+  // Send data to the server
+  const char *message = "Hello, server!";
+  // TODO Find out why this isn't sending data. Are we not flushing?
+  if (!client.send(message, strlen(message) + 1, "127.0.0.1", 50001)) {
+    std::cerr << "Error: Failed to send data\n";
+    return 1;
+  } else {
+    std::cout << "Sent message: " << message << std::endl;
+  }
+  // flush
+  client.close();
+
+  return 0;
+}
+
+// Server code
+// int main() {
+//   UDPPort server;
+// 
+//   // Open the server port for receiving data
+//   if (!server.open(8080)) {
+//     std::cerr << "Error: Failed to open server port\n";
+//     return 1;
+//   }
+// 
+//   // Receive data from the client
+//   char buffer[256];
+//   std::string address;
+//   uint16_t port;
+//   int received = server.receive(buffer, sizeof(buffer), address, port);
+//   if (received < 0) {
+//     std::cerr << "Error: Failed to receive data\n";
+//     return 1;
+//   }
+// 
+//   // Output the received message
+//   std::cout << "Received message from " << address << ":" << port << ": " << buffer << std::endl;
+// 
+//   return 0;
+// }
+// 

--- a/src/exe/udp_client_test/main.cpp
+++ b/src/exe/udp_client_test/main.cpp
@@ -4,27 +4,89 @@
 
 using namespace sputter::net;
 
-// Client code
-int main() {
-  sputter::net::UDPPort client;
+// Constants for RX port number, TX port number, and remote host
+const int RX_PORT = 50000;
+const int TX_PORT = 50001;
+const char* REMOTE_HOST = "127.0.0.1";
 
-  // Open the client port for transmitting data
-  if (!client.open(50000)) {
+// Example of receiving data:
+// std::string address;
+// uint16_t port;
+
+// int bytesReceived = receivingPort.receive(buffer, 256, address, port);
+
+// if (bytesReceived > 0) {
+//   std::cout << "Received " << bytesReceived << " bytes from " << address << ":" << port << std::endl;
+//   std::cout << "Data: " << buffer << std::endl;
+// }
+
+
+// Client code
+int main(int argc, char* argv[]) {
+  // Parse arguments for remote host
+  if (argc > 1) {
+    REMOTE_HOST = argv[1];
+  } else {
+    std::cout << "Usage: " << argv[0] << " [remote host]" << std::endl;
+    return 1;
+  }
+
+  // Open the client port for receiving data (hole punch)
+  sputter::net::UDPPort receivingPort;
+
+  if (!receivingPort.open(RX_PORT)) {
     std::cerr << "Error: Failed to open client port\n";
     return 1;
   }
 
   // Send data to the server
-  const char *message = "Hello, server!";
-  // TODO Find out why this isn't sending data. Are we not flushing?
-  if (!client.send(message, strlen(message) + 1, "127.0.0.1", 50001)) {
+  const char *message = "hole-punch";
+  if (!receivingPort.send(message, strlen(message) + 1, REMOTE_HOST, TX_PORT)) {
     std::cerr << "Error: Failed to send data\n";
     return 1;
-  } else {
-    std::cout << "Sent message: " << message << std::endl;
   }
-  // flush
-  client.close();
+
+  // Open the client port for sending data
+  sputter::net::UDPPort sendingPort;
+
+  if (!sendingPort.open(TX_PORT)) {
+    std::cerr << "Error: Failed to open client port\n";
+    return 1;
+  }
+
+  // Send data until the server sends a message back
+  // First, send a message to the server using the sending port
+  // Then, receive a message from the server using the receiving port
+  // Repeat until a message from the server is received.
+  char buffer[256];
+  std::string address;
+  uint16_t port;
+
+  while (true) {
+    // Send a message to the server
+    const char *message = "Hello, server!";
+    if (!sendingPort.send(message, strlen(message) + 1, REMOTE_HOST, RX_PORT)) {
+      std::cerr << "Error: Failed to send data\n";
+      return 1;
+    }
+
+    // Receive a message from the server
+    int bytesReceived = receivingPort.receive(buffer, 256, address, port);
+
+    if (bytesReceived > 0) {
+      std::cout << "Received " << bytesReceived << " bytes from " << address << ":" << port << std::endl;
+      std::cout << "Data: " << buffer << std::endl;
+      break;
+    }
+
+    // Send another messaage to the server
+    message = "Hello again, server!";
+    if (!sendingPort.send(message, strlen(message) + 1, REMOTE_HOST, RX_PORT)) {
+      std::cerr << "Error: Failed to send data\n";
+      return 1;
+    }
+  }
+
 
   return 0;
 }

--- a/src/exe/udp_client_test/main.cpp
+++ b/src/exe/udp_client_test/main.cpp
@@ -4,10 +4,9 @@
 
 using namespace sputter::net;
 
-// Constants for RX port number, TX port number, and remote host
+// Constants for RX port number, TX port number
 const int RX_PORT = 50000;
 const int TX_PORT = 50001;
-const char* REMOTE_HOST = "127.0.0.1";
 
 // Example of receiving data:
 // std::string address;
@@ -24,6 +23,7 @@ const char* REMOTE_HOST = "127.0.0.1";
 // Client code
 int main(int argc, char* argv[]) {
   // Parse arguments for remote host
+  char* REMOTE_HOST;
   if (argc > 1) {
     REMOTE_HOST = argv[1];
   } else {

--- a/src/lib/sputter/CMakeLists.txt
+++ b/src/lib/sputter/CMakeLists.txt
@@ -15,6 +15,7 @@ file(GLOB SOURCES
     render/*.cpp 
     ui/*.cpp 
     system/*.cpp 
+    net/*.cpp 
     assets/*.cpp 
     physics/*.cpp
     math/*.cpp

--- a/src/lib/sputter/net/port.cpp
+++ b/src/lib/sputter/net/port.cpp
@@ -31,7 +31,7 @@ bool UDPPort::open(uint16_t port) {
   bindAddress.sin_family = AF_INET;
   bindAddress.sin_addr.s_addr = htonl(INADDR_ANY);
   bindAddress.sin_port = htons(port);
-  if (bind(socketHandle, (sockaddr *)&bindAddress, sizeof(bindAddress)) < 0) {
+  if (bind(socketHandle, reinterpret_cast<sockaddr *>(&bindAddress), sizeof(bindAddress)) < 0) {
     LOG(ERROR) << "Error: Failed to create socket\n";
     return false;
   }

--- a/src/lib/sputter/net/port.cpp
+++ b/src/lib/sputter/net/port.cpp
@@ -26,8 +26,7 @@ bool UDPPort::open(uint16_t port) {
   }
 
   // Store port address
-  sockaddr_in bindAddress;
-  memset(&bindAddress, 0, sizeof(bindAddress));
+  sockaddr_in bindAddress = {};
   bindAddress.sin_family = AF_INET;
   bindAddress.sin_addr.s_addr = htonl(INADDR_ANY);
   bindAddress.sin_port = htons(port);
@@ -49,8 +48,7 @@ void UDPPort::close() {
 bool UDPPort::send(const void *data, int dataSize, const std::string &address, uint16_t port) {
   RELEASE_CHECK(socketHandle >= 0, "Socket is not open");
 
-  sockaddr_in dest;
-  memset(&dest, 0, sizeof(dest));
+  sockaddr_in dest = {};
   dest.sin_family = AF_INET;
   dest.sin_port = htons(port);
   if (inet_pton(AF_INET, address.c_str(), &dest.sin_addr) != 1) {
@@ -83,9 +81,7 @@ bool UDPPort::send(const void *data, int dataSize, const std::string &address, u
 int UDPPort::receive(void *data, int dataSize, std::string &address, uint16_t &port) {
   RELEASE_CHECK(socketHandle >= 0, "Socket is not open");
 
-  sockaddr_in src;
-  socklen_t srcLength = sizeof(src);
-  memset(&src, 0, sizeof(src));
+  sockaddr_in src = {};
 
   int received = recvfrom(socketHandle, data, dataSize, 0, reinterpret_cast<sockaddr *>(&src), &srcLength);
   if (received < 0) {

--- a/src/lib/sputter/net/port.cpp
+++ b/src/lib/sputter/net/port.cpp
@@ -10,17 +10,13 @@
 
 using namespace sputter::net;
 
-UDPPort::UDPPort()
-    : socketHandle(-1) {
-}
-
 UDPPort::~UDPPort() {
   close();
 }
 
 bool UDPPort::open(uint16_t port) {
-  socketHandle = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-  if (socketHandle < 0) {
+  m_socketHandle = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+  if (m_socketHandle < 0) {
     LOG(ERROR) << "Error: Failed to create socket\n";
     return false;
   }
@@ -30,7 +26,7 @@ bool UDPPort::open(uint16_t port) {
   bindAddress.sin_family = AF_INET;
   bindAddress.sin_addr.s_addr = htonl(INADDR_ANY);
   bindAddress.sin_port = htons(port);
-  if (bind(socketHandle, reinterpret_cast<sockaddr *>(&bindAddress), sizeof(bindAddress)) < 0) {
+  if (bind(m_socketHandle, reinterpret_cast<sockaddr *>(&bindAddress), sizeof(bindAddress)) < 0) {
     LOG(ERROR) << "Error: Failed to create socket\n";
     return false;
   }
@@ -39,14 +35,14 @@ bool UDPPort::open(uint16_t port) {
 }
 
 void UDPPort::close() {
-  if (socketHandle >= 0) {
-    ::close(socketHandle);
-    socketHandle = -1;
+  if (m_socketHandle >= 0) {
+    ::close(m_socketHandle);
+    m_socketHandle = -1;
   }
 }
 
 bool UDPPort::send(const void *data, int dataSize, const std::string &address, uint16_t port) {
-  RELEASE_CHECK(socketHandle >= 0, "Socket is not open");
+  RELEASE_CHECK(m_socketHandle >= 0, "Socket is not open");
 
   sockaddr_in dest = {};
   dest.sin_family = AF_INET;
@@ -65,7 +61,7 @@ bool UDPPort::send(const void *data, int dataSize, const std::string &address, u
 
 #endif
 
-  int sent = sendto(socketHandle, data, dataSize, 0, reinterpret_cast<sockaddr *>(&dest), sizeof(dest));
+  int sent = sendto(m_socketHandle, data, dataSize, 0, reinterpret_cast<sockaddr *>(&dest), sizeof(dest));
   if (sent < 0) {
     LOG(WARNING) << "Error: Failed to send data\n";
     return false;
@@ -79,11 +75,11 @@ bool UDPPort::send(const void *data, int dataSize, const std::string &address, u
 }
 
 int UDPPort::receive(void *data, int dataSize, std::string &address, uint16_t &port) {
-  RELEASE_CHECK(socketHandle >= 0, "Socket is not open");
+  RELEASE_CHECK(m_socketHandle >= 0, "Socket is not open");
 
   sockaddr_in src = {};
 
-  int received = recvfrom(socketHandle, data, dataSize, 0, reinterpret_cast<sockaddr *>(&src), &srcLength);
+  int received = recvfrom(m_socketHandle, data, dataSize, 0, reinterpret_cast<sockaddr *>(&src), &srcLength);
   if (received < 0) {
     LOG(WARNING) << "Error: Failed to receive data\n";
     return -1;

--- a/src/lib/sputter/net/port.cpp
+++ b/src/lib/sputter/net/port.cpp
@@ -1,0 +1,108 @@
+#include "port.h"
+
+#include <cstring>
+#include <iostream>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+using namespace sputter::net;
+
+UDPPort::UDPPort()
+    : socketHandle(-1) {
+}
+
+UDPPort::~UDPPort() {
+  close();
+}
+
+bool UDPPort::open(uint16_t port) {
+  socketHandle = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+  if (socketHandle < 0) {
+    std::cerr << "Error: Failed to create socket\n";
+    return false;
+  }
+
+  // Store port address
+  sockaddr_in bindAddress;
+  memset(&bindAddress, 0, sizeof(bindAddress));
+  bindAddress.sin_family = AF_INET;
+  bindAddress.sin_addr.s_addr = htonl(INADDR_ANY);
+  bindAddress.sin_port = htons(port);
+  if (bind(socketHandle, (sockaddr *)&bindAddress, sizeof(bindAddress)) < 0) {
+    std::cerr << "Error: Failed to bind socket\n";
+    return false;
+  }
+
+  return true;
+}
+
+void UDPPort::close() {
+  if (socketHandle >= 0) {
+    ::close(socketHandle);
+    socketHandle = -1;
+  }
+}
+
+bool UDPPort::send(const void *data, int dataSize, const std::string &address, uint16_t port) {
+  if (socketHandle < 0) {
+    std::cerr << "Error: Socket is not open\n";
+    return false;
+  }
+
+  sockaddr_in dest;
+  memset(&dest, 0, sizeof(dest));
+  dest.sin_family = AF_INET;
+  dest.sin_port = htons(port);
+  if (inet_pton(AF_INET, address.c_str(), &dest.sin_addr) != 1) {
+    std::cerr << "Error: Failed to convert address to binary\n";
+    return false;
+  }
+
+  // Print the address and port we're sending to
+  char addressBuffer[INET_ADDRSTRLEN];
+  inet_ntop(AF_INET, &dest.sin_addr, addressBuffer, sizeof(addressBuffer));
+  std::cout << "Sending to " << addressBuffer << ":" << port << std::endl;
+
+  int sent = sendto(socketHandle, data, dataSize, 0, reinterpret_cast<sockaddr *>(&dest), sizeof(dest));
+  if (sent < 0) {
+    std::cerr << "Error: Failed to send data\n";
+    return false;
+  } else {
+    std::cout << "Sent " << sent << " bytes" << std::endl;
+  }
+
+  return true;
+}
+
+int UDPPort::receive(void *data, int dataSize, std::string &address, uint16_t &port) {
+  if (socketHandle < 0) {
+    std::cerr << "Error: Socket is not open\n";
+    return -1;
+  }
+
+  sockaddr_in src;
+  socklen_t srcLength = sizeof(src);
+  memset(&src, 0, sizeof(src));
+
+  int received = recvfrom(socketHandle, data, dataSize, 0, reinterpret_cast<sockaddr *>(&src), &srcLength);
+  if (received < 0) {
+    std::cerr << "Error: Failed to receive data\n";
+    return -1;
+  }
+
+  // Convert address to string and assign to &address
+  char addressBuffer[INET_ADDRSTRLEN];
+  if (inet_ntop(AF_INET, &src.sin_addr, addressBuffer, sizeof(addressBuffer)) == nullptr) {
+    std::cerr << "Error: Failed to convert address to string\n";
+    return -1;
+  }
+  address = addressBuffer;
+
+  // Assign port to &port
+  port = ntohs(src.sin_port);
+
+  return received;
+
+}

--- a/src/lib/sputter/net/port.h
+++ b/src/lib/sputter/net/port.h
@@ -16,7 +16,7 @@ namespace sputter { namespace net { class UDPPort {
         int receive(void *data, int dataSize, std::string &address, uint16_t &port);
     
     private:
-        int socketHandle;
+        int m_socketHandle = -1;
     };
 }}
 

--- a/src/lib/sputter/net/port.h
+++ b/src/lib/sputter/net/port.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace sputter { namespace net { class UDPPort {
+    public:
+        UDPPort();
+        ~UDPPort();
+    
+        bool open(uint16_t port);
+        // Close is automatically called in the destructor but can be called manually here.
+        void close();
+    
+        bool send(const void *data, int dataSize, const std::string &address, uint16_t port);
+        int receive(void *data, int dataSize, std::string &address, uint16_t &port);
+    
+    private:
+        int socketHandle;
+    };
+}}
+


### PR DESCRIPTION
This is a demonstration of a peer to peer connection with UDP punchthrough. I have tested this with two hosts on my internal network. I'd like to test this over the public internet next.

There is no relay server yet. The client operates by directly providing the remote IP address. 

If we get issues testing over the public internet, I'd suggest waiting until we have a relay server so we can debug things more effectively. 

Here is a diagram of how it works:

![image](https://user-images.githubusercontent.com/13189762/216775852-b7d32d30-2222-42bf-bb96-643fc6e7e4b2.png)

A hole punched port serves as the receiving port.

A transmitting port is opened and sends to the other server's hole punch port.
![image](https://user-images.githubusercontent.com/13189762/216775892-cb3d4f3c-e492-4056-8a33-e248a535b470.png)

